### PR TITLE
Update PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "php": ">=5.4",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "phpunit/phpunit": "^5.4|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.0",
         "zendframework/zend-diactoros": "^1.0",
         "guzzlehttp/psr7": "^1.0",
         "slim/slim": "^3.0",
@@ -26,9 +26,9 @@
             "Http\\Psr7Test\\": "src/"
         }
     },
-    "autoloaddev": {
+    "autoload-dev": {
         "psr-4": {
-            "Http\\Psr7Test\\Tests": "tests/"
+            "Http\\Psr7Test\\Tests\\": "tests/"
         }
     },
     "scripts": {

--- a/src/BaseTest.php
+++ b/src/BaseTest.php
@@ -5,6 +5,7 @@ namespace Http\Psr7Test;
 use GuzzleHttp\Psr7\Stream as GuzzleStream;
 use GuzzleHttp\Psr7\UploadedFile as GuzzleUploadedFile;
 use GuzzleHttp\Psr7\Uri as GuzzleUri;
+use PHPUnit\Framework\TestCase;
 use Slim\Http\Uri as SlimUri;
 use Zend\Diactoros\Stream as ZendStream;
 use Zend\Diactoros\Uri as ZendUri;
@@ -13,7 +14,7 @@ use Zend\Diactoros\UploadedFile as ZendUploadedFile;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class BaseTest extends \PHPUnit_Framework_TestCase
+class BaseTest extends TestCase
 {
     protected function assertNotSameObject($a, $b)
     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

- Update to modern PHPUnit version with namespaces
- Moved PHPUnit to require section sice this library is for testing only and simply requires PHPUnit
- fix autoload-dev

#### Why?

I have issues implementing this for compatibiity tests because of the PHPUnit version.