### PR TITLE
Update some TestCases with issues

### DIFF
--- a/src/StreamIntegrationTest.php
+++ b/src/StreamIntegrationTest.php
@@ -27,13 +27,12 @@ abstract class StreamIntegrationTest extends BaseTest
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $url = 'https://raw.githubusercontent.com/php-http/multipart-stream-builder/master/tests/Resources/httplug.png';
-        $resource = fopen($url, 'r');
+        $resource = fopen(__FILE__, 'r');
         $stream = $this->createStream($resource);
 
         // Make sure this does not throw exception
         $content = (string) $stream;
-        $this->assertTrue(!empty($content), 'You MUST be able to convert a read only stream to string');
+        $this->assertNotEmpty($content, 'You MUST be able to convert a read only stream to string');
     }
 
     public function testToStringRewindStreamBeforeToString()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | partially #7 
| License         | MIT


#### What's in this PR?

- Fixes an issue where an integer is set to ServerRequest::withParsedBody which should cause an InvalidArgumentException as it is defined like:
  - `@param null|array|object $data`
  - `@throws \InvalidArgumentException if an unsupported argument type is provided.`
- Also added invalid Testcases for this
- Updated StreamTest::testToStringReadOnlyStreams to use current file for test instead of remote
  - so we do not depend on a remote file and
  - the remote file doesn't work here