### PR TITLE
Use Slim-Http for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "zendframework/zend-diactoros": "^1.0",
         "guzzlehttp/psr7": "^1.0",
-        "slim/slim": "^3.0",
+        "slim/http": "^0.3",
         "nyholm/psr7": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no|yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

We should test against Slim-Http instead of the whole Framework. Slim-Http is the Psr-7 implementation from Slim V3 as separate package and will be used from Slim V4 on.
We should not test against the whole framework since it is not just Psr-7.