### PR TITLE
Better test if a Stream is closed

### DIFF
--- a/src/StreamIntegrationTest.php
+++ b/src/StreamIntegrationTest.php
@@ -60,8 +60,9 @@ abstract class StreamIntegrationTest extends BaseTest
         fwrite($resource, 'abcdef');
         $stream = $this->createStream($resource);
 
+        $this->assertTrue(is_resource($resource));
         $stream->close();
-        $this->assertFalse(@fclose($resource));
+        $this->assertFalse(is_resource($resource));
     }
 
     public function testDetach()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | found in review of slimphp/Slim-Http#32
| License         | MIT


#### What's in this PR? Why?

- the @ suppresses warnings/errors which shoud be omitted
- if a resource is closed it is not a resource anymore, so we can check it using `is_resource`
