### PR TITLE
Split of tests requiring live internet connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Please see the [official documentation](http://docs.php-http.org/en/latest).
 $ composer test
 ```
 
+It is also possible to exclude tests that require a live internet connection:
+
+``` bash
+$ composer test -- --exclude-group internet
+```
 
 ## Contributing
 

--- a/src/StreamIntegrationTest.php
+++ b/src/StreamIntegrationTest.php
@@ -137,6 +137,16 @@ abstract class StreamIntegrationTest extends BaseTest
         fwrite($resource, 'abcdef');
         $stream = $this->createStream($resource);
         $this->assertTrue($stream->isSeekable());
+    }
+
+    /**
+     * @group internet
+     */
+    public function testIsNotSeekable()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
 
         $url = 'https://raw.githubusercontent.com/php-http/multipart-stream-builder/master/tests/Resources/httplug.png';
         $resource = fopen($url, 'r');
@@ -154,6 +164,16 @@ abstract class StreamIntegrationTest extends BaseTest
         fwrite($resource, 'abcdef');
         $stream = $this->createStream($resource);
         $this->assertTrue($stream->isWritable());
+    }
+
+    /**
+     * @group internet
+     */
+    public function testIsNotWritable()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
 
         $url = 'https://raw.githubusercontent.com/php-http/multipart-stream-builder/master/tests/Resources/httplug.png';
         $resource = fopen($url, 'r');
@@ -171,6 +191,16 @@ abstract class StreamIntegrationTest extends BaseTest
         fwrite($resource, 'abcdef');
         $stream = $this->createStream($resource);
         $this->assertTrue($stream->isReadable());
+    }
+
+    /**
+     * @group internet
+     */
+    public function testIsNotReadable()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
 
         $url = 'https://raw.githubusercontent.com/php-http/multipart-stream-builder/master/tests/Resources/httplug.png';
         $resource = fopen($url, 'r');
@@ -207,6 +237,7 @@ abstract class StreamIntegrationTest extends BaseTest
     }
 
     /**
+     * @group internet
      * @expectedException \RuntimeException
      */
     public function testRewindNotSeekable()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

A reshuffling of some Stream tests. Tests that require a live internet connection are now grouped together in a PHPUnit `@group` called “internet”. This group
name follows the prior art [set by by Guzzle](https://guzzle3.readthedocs.io/testing/unit-testing.html#group-internet-annotation).


#### Why?

I ran into this when repeatedly testing [Nyholm/psr7](https://github.com/Nyholm/psr7) on a flaky 4G connection, and it bothered me when tests either took really long or threw exceptions.

I am not alone in developing on a non-stellar internet connection. Not to mention people who do development in offline environments. So I thought this worth fixing.


#### Example Usage

``` bash
$ phpunit --exclude-group internet
```


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)