### PR TITLE
Test empty header field

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -106,6 +106,10 @@ trait MessageTrait
 
         $message = $initialMessage->withHeader('x-foo', ['bar', 'baz']);
         $this->assertRegExp('|bar, ?baz|', $message->getHeaderLine('x-foo'));
+
+        $message = $initialMessage->withHeader('Bar', '');
+        $this->assertTrue($message->hasHeader('Bar'));
+        $this->assertEquals([''], $message->getHeader('Bar'));
     }
 
     /**


### PR DESCRIPTION
#### What's in this PR?

Adding one extra test for `withHeader`.


#### Why?

It doesn’t look like there was a test for empty header values, those are allowed per RFC 7230, see Nyholm/psr7#38.


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

- [ ] Verify that the checks for disallowing empty header names works.
- [ ] Possibly add more tests? Multiple of the same header with empty values? How far does this need to go?

Happy to update the CHANGELOG when decided that the PR is done.