### PR TITLE
Improve tests

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -16,6 +16,11 @@ trait MessageTrait
      */
     abstract protected function getMessage();
 
+    /**
+     * @return MessageInterface
+     */
+    abstract protected function getClone();
+
     public function testProtocolVersion()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -37,12 +42,20 @@ trait MessageTrait
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $message = $this->getMessage()->withAddedHeader('content-type', 'text/html');
-        $message = $message->withAddedHeader('content-type', 'text/plain');
+        $initialMessage = $this->getMessage();
+
+        $message = $initialMessage
+            ->withAddedHeader('content-type', 'text/html')
+            ->withAddedHeader('content-type', 'text/plain');
+
+        $this->assertEquals($initialMessage, $this->getClone());
+
         $headers = $message->getHeaders();
 
         $this->assertTrue(isset($headers['content-type']));
         $this->assertCount(2, $headers['content-type']);
+        $this->assertContains('text/html', $headers['content-type']);
+        $this->assertContains('text/plain', $headers['content-type']);
     }
 
     public function testHasHeader()

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -16,11 +16,6 @@ trait MessageTrait
      */
     abstract protected function getMessage();
 
-    /**
-     * @return MessageInterface
-     */
-    abstract protected function getClone();
-
     public function testProtocolVersion()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -28,10 +23,12 @@ trait MessageTrait
         }
 
         $initialMessage = $this->getMessage();
+        $original = clone $initialMessage;
+
         $message = $initialMessage->withProtocolVersion('1.0');
 
         $this->assertNotSameObject($initialMessage, $message);
-        $this->assertEquals($initialMessage, $this->getClone());
+        $this->assertEquals($initialMessage, $original, 'Message object MUST not be mutated');
 
         $this->assertSame('1.0', $message->getProtocolVersion());
     }
@@ -43,12 +40,13 @@ trait MessageTrait
         }
 
         $initialMessage = $this->getMessage();
+        $original = clone $initialMessage;
 
         $message = $initialMessage
             ->withAddedHeader('content-type', 'text/html')
             ->withAddedHeader('content-type', 'text/plain');
 
-        $this->assertEquals($initialMessage, $this->getClone());
+        $this->assertEquals($initialMessage, $original, 'Message object MUST not be mutated');
 
         $headers = $message->getHeaders();
 
@@ -109,9 +107,11 @@ trait MessageTrait
         }
 
         $initialMessage = $this->getMessage();
+        $original = clone $initialMessage;
+
         $message = $initialMessage->withHeader('content-type', 'text/html');
         $this->assertNotSameObject($initialMessage, $message);
-        $this->assertEquals($initialMessage, $this->getClone());
+        $this->assertEquals($initialMessage, $original, 'Message object MUST not be mutated');
         $this->assertEquals('text/html', $message->getHeaderLine('content-type'));
 
         $message = $initialMessage->withHeader('content-type', 'text/plain');
@@ -243,10 +243,11 @@ trait MessageTrait
         }
 
         $initialMessage = $this->getMessage();
+        $original = clone $initialMessage;
         $stream = $this->buildStream('foo');
         $message = $initialMessage->withBody($stream);
         $this->assertNotSameObject($initialMessage, $message);
-        $this->assertEquals($initialMessage, $this->getClone());
+        $this->assertEquals($initialMessage, $original, 'Message object MUST not be mutated');
 
         $this->assertEquals($stream, $message->getBody());
     }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -24,9 +24,11 @@ trait MessageTrait
 
         $initialMessage = $this->getMessage();
         $message = $initialMessage->withProtocolVersion('1.0');
-        $this->assertNotSameObject($initialMessage, $message);
 
-        $this->assertEquals('1.0', $message->getProtocolVersion());
+        $this->assertNotSameObject($initialMessage, $message);
+        $this->assertEquals($initialMessage, $this->getClone());
+
+        $this->assertSame('1.0', $message->getProtocolVersion());
     }
 
     public function testGetHeaders()
@@ -69,7 +71,7 @@ trait MessageTrait
         $this->assertCount(2, $message->getHeader('CONTENT-TYPE'));
         $emptyHeader = $message->getHeader('Bar');
         $this->assertCount(0, $emptyHeader);
-        $this->assertTrue(is_array($emptyHeader));
+        $this->assertInternalType('array', $emptyHeader);
     }
 
     public function testGetHeaderLine()
@@ -84,7 +86,7 @@ trait MessageTrait
         $this->assertRegExp('|text/html, ?text/plain|', $message->getHeaderLine('Content-Type'));
         $this->assertRegExp('|text/html, ?text/plain|', $message->getHeaderLine('CONTENT-TYPE'));
 
-        $this->assertEquals('', $message->getHeaderLine('Bar'));
+        $this->assertSame('', $message->getHeaderLine('Bar'));
     }
 
     public function testWithHeader()
@@ -96,6 +98,7 @@ trait MessageTrait
         $initialMessage = $this->getMessage();
         $message = $initialMessage->withHeader('content-type', 'text/html');
         $this->assertNotSameObject($initialMessage, $message);
+        $this->assertEquals($initialMessage, $this->getClone());
         $this->assertEquals('text/html', $message->getHeaderLine('content-type'));
 
         $message = $initialMessage->withHeader('content-type', 'text/plain');
@@ -109,7 +112,7 @@ trait MessageTrait
 
         $message = $initialMessage->withHeader('Bar', '');
         $this->assertTrue($message->hasHeader('Bar'));
-        $this->assertEquals([''], $message->getHeader('Bar'));
+        $this->assertSame([''], $message->getHeader('Bar'));
     }
 
     /**
@@ -230,6 +233,7 @@ trait MessageTrait
         $stream = $this->buildStream('foo');
         $message = $initialMessage->withBody($stream);
         $this->assertNotSameObject($initialMessage, $message);
+        $this->assertEquals($initialMessage, $this->getClone());
 
         $this->assertEquals($stream, $message->getBody());
     }

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -23,13 +23,6 @@ abstract class RequestIntegrationTest extends BaseTest
     private $request;
 
     /**
-     * This object is used in order to ensure that the state of the object is kept.
-     *
-     * @var RequestInterface
-     */
-    private $clone;
-
-    /**
      * @return RequestInterface that is used in the tests
      */
     abstract public function createSubject();
@@ -37,17 +30,11 @@ abstract class RequestIntegrationTest extends BaseTest
     protected function setUp()
     {
         $this->request = $this->createSubject();
-        $this->clone = clone $this->request;
     }
 
     protected function getMessage()
     {
         return $this->request;
-    }
-
-    protected function getClone()
-    {
-        return $this->clone;
     }
 
     public function testRequestTarget()
@@ -56,11 +43,12 @@ abstract class RequestIntegrationTest extends BaseTest
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $original = clone $this->request;
         $this->assertEquals('/', $this->request->getRequestTarget());
 
         $request = $this->request->withRequestTarget('*');
         $this->assertNotSameObject($this->request, $request);
-        $this->assertEquals($this->request, $this->clone);
+        $this->assertEquals($this->request, $original, 'Request object MUST not be mutated');
         $this->assertEquals('*', $request->getRequestTarget());
     }
 
@@ -71,10 +59,11 @@ abstract class RequestIntegrationTest extends BaseTest
         }
 
         $this->assertEquals('GET', $this->request->getMethod());
+        $original = clone $this->request;
 
         $request = $this->request->withMethod('POST');
         $this->assertNotSameObject($this->request, $request);
-        $this->assertEquals($this->request, $this->clone);
+        $this->assertEquals($this->request, $original, 'Request object MUST not be mutated');
         $this->assertEquals('POST', $request->getMethod());
 
         $request = $this->request->withMethod('head');
@@ -111,20 +100,21 @@ abstract class RequestIntegrationTest extends BaseTest
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
+        $original = clone $this->request;
 
         $this->assertInstanceOf(UriInterface::class, $this->request->getUri());
 
         $uri = $this->buildUri('http://www.foo.com/bar');
         $request = $this->request->withUri($uri);
         $this->assertNotSameObject($this->request, $request);
-        $this->assertEquals($this->request, $this->clone);
+        $this->assertEquals($this->request, $original, 'Request object MUST not be mutated');
         $this->assertEquals('www.foo.com', $request->getHeaderLine('host'));
         $this->assertInstanceOf(UriInterface::class, $request->getUri());
         $this->assertEquals('http://www.foo.com/bar', (string) $request->getUri());
 
         $request = $request->withUri($this->buildUri('/foobar'));
         $this->assertNotSameObject($this->request, $request);
-        $this->assertEquals($this->request, $this->clone);
+        $this->assertEquals($this->request, $original, 'Request object MUST not be mutated');
         $this->assertEquals('www.foo.com', $request->getHeaderLine('host'), 'If the URI does not contain a host component, any pre-existing Host header MUST be carried over to the returned request.');
         $this->assertEquals('/foobar', (string) $request->getUri());
     }

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -47,7 +47,7 @@ abstract class RequestIntegrationTest extends BaseTest
 
     protected function getClone()
     {
-        return $this->request;
+        return $this->clone;
     }
 
     public function testRequestTarget()

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -23,6 +23,13 @@ abstract class RequestIntegrationTest extends BaseTest
     private $request;
 
     /**
+     * This object is used in order to ensure that the state of the object is kept.
+     *
+     * @var RequestInterface
+     */
+    private $clone;
+
+    /**
      * @return RequestInterface that is used in the tests
      */
     abstract public function createSubject();
@@ -30,9 +37,15 @@ abstract class RequestIntegrationTest extends BaseTest
     protected function setUp()
     {
         $this->request = $this->createSubject();
+        $this->clone = clone $this->request;
     }
 
     protected function getMessage()
+    {
+        return $this->request;
+    }
+
+    protected function getClone()
     {
         return $this->request;
     }
@@ -47,6 +60,7 @@ abstract class RequestIntegrationTest extends BaseTest
 
         $request = $this->request->withRequestTarget('*');
         $this->assertNotSameObject($this->request, $request);
+        $this->assertEquals($this->request, $this->clone);
         $this->assertEquals('*', $request->getRequestTarget());
     }
 
@@ -60,6 +74,7 @@ abstract class RequestIntegrationTest extends BaseTest
 
         $request = $this->request->withMethod('POST');
         $this->assertNotSameObject($this->request, $request);
+        $this->assertEquals($this->request, $this->clone);
         $this->assertEquals('POST', $request->getMethod());
 
         $request = $this->request->withMethod('head');
@@ -99,11 +114,14 @@ abstract class RequestIntegrationTest extends BaseTest
         $uri = $this->buildUri('http://www.foo.com/bar');
         $request = $this->request->withUri($uri);
         $this->assertNotSameObject($this->request, $request);
+        $this->assertEquals($this->request, $this->clone);
         $this->assertEquals('www.foo.com', $request->getHeaderLine('host'));
+        $this->assertInstanceOf(UriInterface::class, $request->getUri());
         $this->assertEquals('http://www.foo.com/bar', (string) $request->getUri());
 
         $request = $request->withUri($this->buildUri('/foobar'));
         $this->assertNotSameObject($this->request, $request);
+        $this->assertEquals($this->request, $this->clone);
         $this->assertEquals('www.foo.com', $request->getHeaderLine('host'), 'If the URI does not contain a host component, any pre-existing Host header MUST be carried over to the returned request.');
         $this->assertEquals('/foobar', (string) $request->getUri());
     }

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -97,6 +97,9 @@ abstract class RequestIntegrationTest extends BaseTest
     public function getInvalidMethods()
     {
         return [
+            [null],
+            [1],
+            [1.01],
             [false],
             [['foo']],
             [new \stdClass()],

--- a/src/ResponseIntegrationTest.php
+++ b/src/ResponseIntegrationTest.php
@@ -44,6 +44,11 @@ abstract class ResponseIntegrationTest extends BaseTest
         return $this->response;
     }
 
+    protected function getClone()
+    {
+        return $this->clone;
+    }
+
     public function testStatusCode()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/ResponseIntegrationTest.php
+++ b/src/ResponseIntegrationTest.php
@@ -22,13 +22,6 @@ abstract class ResponseIntegrationTest extends BaseTest
     private $response;
 
     /**
-     * This object is used in order to ensure that the state of the object is kept.
-     *
-     * @var ResponseInterface
-     */
-    private $clone;
-
-    /**
      * @return ResponseInterface that is used in the tests
      */
     abstract public function createSubject();
@@ -36,17 +29,11 @@ abstract class ResponseIntegrationTest extends BaseTest
     protected function setUp()
     {
         $this->response = $this->createSubject();
-        $this->clone = clone $this->response;
     }
 
     protected function getMessage()
     {
         return $this->response;
-    }
-
-    protected function getClone()
-    {
-        return $this->clone;
     }
 
     public function testStatusCode()
@@ -55,9 +42,10 @@ abstract class ResponseIntegrationTest extends BaseTest
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $original = clone $this->response;
         $response = $this->response->withStatus(204);
         $this->assertNotSameObject($this->response, $response);
-        $this->assertEquals($this->response, $this->clone);
+        $this->assertEquals($this->response, $original, 'Response MUST not be mutated');
         $this->assertSame(204, $response->getStatusCode());
     }
 

--- a/src/ResponseIntegrationTest.php
+++ b/src/ResponseIntegrationTest.php
@@ -22,6 +22,13 @@ abstract class ResponseIntegrationTest extends BaseTest
     private $response;
 
     /**
+     * This object is used in order to ensure that the state of the object is kept.
+     *
+     * @var ResponseInterface
+     */
+    private $clone;
+
+    /**
      * @return ResponseInterface that is used in the tests
      */
     abstract public function createSubject();
@@ -29,6 +36,7 @@ abstract class ResponseIntegrationTest extends BaseTest
     protected function setUp()
     {
         $this->response = $this->createSubject();
+        $this->clone = clone $this->response;
     }
 
     protected function getMessage()
@@ -44,7 +52,8 @@ abstract class ResponseIntegrationTest extends BaseTest
 
         $response = $this->response->withStatus(204);
         $this->assertNotSameObject($this->response, $response);
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals($this->response, $this->clone);
+        $this->assertSame(204, $response->getStatusCode());
     }
 
     /**
@@ -79,7 +88,7 @@ abstract class ResponseIntegrationTest extends BaseTest
         }
 
         $response = $this->response->withStatus(204, 'Foobar');
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertSame(204, $response->getStatusCode());
         $this->assertEquals('Foobar', $response->getReasonPhrase());
     }
 }

--- a/src/ServerRequestIntegrationTest.php
+++ b/src/ServerRequestIntegrationTest.php
@@ -85,7 +85,7 @@ abstract class ServerRequestIntegrationTest extends BaseTest
         $this->assertEmpty($this->serverRequest->getUploadedFiles(), 'withUploadedFiles MUST be immutable');
 
         $files = $new->getUploadedFiles();
-        $this->assertEquals(1, count($files));
+        $this->assertCount(1, $files);
         $this->assertEquals($file, $files[0]);
     }
 
@@ -162,7 +162,7 @@ abstract class ServerRequestIntegrationTest extends BaseTest
         $new = $this->serverRequest->withAttribute('foo', 'bar');
         $this->assertEquals('bar', $new->getAttribute('foo'));
         $this->assertEquals('baz', $new->getAttribute('not found', 'baz'));
-        $this->assertEquals(null, $new->getAttribute('not found'));
+        $this->assertNull($new->getAttribute('not found'));
     }
 
     public function testWithoutAttribute()
@@ -175,6 +175,6 @@ abstract class ServerRequestIntegrationTest extends BaseTest
         $without = $with->withoutAttribute('foo');
 
         $this->assertEquals('bar', $with->getAttribute('foo'), 'withoutAttribute MUST be immutable');
-        $this->assertEquals(null, $without->getAttribute('foo'));
+        $this->assertNull($without->getAttribute('foo'));
     }
 }

--- a/src/StreamIntegrationTest.php
+++ b/src/StreamIntegrationTest.php
@@ -101,13 +101,13 @@ abstract class StreamIntegrationTest extends BaseTest
         fwrite($resource, 'abcdef');
         $stream = $this->createStream($resource);
 
-        $this->assertEquals(6, $stream->tell());
+        $this->assertSame(6, $stream->tell());
         $stream->seek(0);
-        $this->assertEquals(0, $stream->tell());
+        $this->assertSame(0, $stream->tell());
         $stream->seek(3);
-        $this->assertEquals(3, $stream->tell());
+        $this->assertSame(3, $stream->tell());
         $stream->seek(6);
-        $this->assertEquals(6, $stream->tell());
+        $this->assertSame(6, $stream->tell());
     }
 
     public function testEof()
@@ -263,7 +263,7 @@ abstract class StreamIntegrationTest extends BaseTest
         $stream = $this->createStream($resource);
         $bytes = $stream->write('def');
 
-        $this->assertEquals(3, $bytes);
+        $this->assertSame(3, $bytes);
         $this->assertEquals('abcdef', (string) $stream);
     }
 
@@ -298,6 +298,6 @@ abstract class StreamIntegrationTest extends BaseTest
 
         $stream->seek(3);
         $this->assertEquals('def', $stream->getContents());
-        $this->assertEquals('', $stream->getContents());
+        $this->assertSame('', $stream->getContents());
     }
 }

--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -28,7 +28,7 @@ abstract class UriIntegrationTest extends BaseTest
         }
 
         $uri = $this->createUri('/');
-        $this->assertEquals('', $uri->getScheme());
+        $this->assertSame('', $uri->getScheme());
 
         $uri = $this->createUri('https://foo.com/');
         $this->assertEquals('https', $uri->getScheme());
@@ -103,7 +103,7 @@ abstract class UriIntegrationTest extends BaseTest
         }
 
         $uri = $this->createUri('/');
-        $this->assertEquals('', $uri->getHost());
+        $this->assertSame('', $uri->getHost());
 
         $uri = $this->createUri('http://www.foo.com/');
         $this->assertEquals('www.foo.com', $uri->getHost());
@@ -128,7 +128,7 @@ abstract class UriIntegrationTest extends BaseTest
         $this->assertNull($uri->getPort());
 
         $uri = $this->createUri('http://www.foo.com:81/');
-        $this->assertEquals(81, $uri->getPort());
+        $this->assertSame(81, $uri->getPort());
     }
 
     /**
@@ -140,7 +140,7 @@ abstract class UriIntegrationTest extends BaseTest
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $this->assertEquals($expected, $uri->getPath());
+        $this->assertSame($expected, $uri->getPath());
     }
 
     public function getPaths()
@@ -164,7 +164,7 @@ abstract class UriIntegrationTest extends BaseTest
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $this->assertEquals($expected, $uri->getQuery());
+        $this->assertSame($expected, $uri->getQuery());
     }
 
     public function getQueries()
@@ -205,6 +205,7 @@ abstract class UriIntegrationTest extends BaseTest
         $expected = 'https://0:0@0:1/0?0#0';
         $uri = $this->createUri($expected);
 
+        $this->assertInstanceOf(UriInterface::class, $uri);
         $this->assertSame($expected, (string) $uri);
     }
 
@@ -222,6 +223,7 @@ abstract class UriIntegrationTest extends BaseTest
             ->withFragment('0')
         ;
 
+        $this->assertInstanceOf(UriInterface::class, $uri);
         $this->assertSame($expected, (string) $uri);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

- Use assertSame where it had meaning.
- Use a clone of the objects under testing. This way we ensure that the object has not changed state.
- Added some more assertions.

#### To Do

- [x] Need to check more places about using `assertEqual` with a clone.
