### PR TITLE
slim/http is now slim/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "guzzlehttp/psr7": "^1.4",
         "nyholm/psr7": "dev-master",
         "ringcentral/psr7": "^1.2",
-        "slim/http": "^0.3",
+        "slim/psr7": "dev-master",
         "zendframework/zend-diactoros": "^1.8"
     },
     "extra": {

--- a/src/BaseTest.php
+++ b/src/BaseTest.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Psr7\UploadedFile as GuzzleUploadedFile;
 use GuzzleHttp\Psr7\Uri as GuzzleUri;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UriInterface;
-use Slim\Http\Uri as SlimUri;
+use Slim\Psr7\Uri as SlimUri;
 use Zend\Diactoros\Stream as ZendStream;
 use Zend\Diactoros\Uri as ZendUri;
 use Zend\Diactoros\UploadedFile as ZendUploadedFile;

--- a/tests/Slim/RequestTest.php
+++ b/tests/Slim/RequestTest.php
@@ -3,15 +3,22 @@
 namespace Http\Psr7Test\Tests\Slim;
 
 use Http\Psr7Test\RequestIntegrationTest;
-use Slim\Http\Body;
-use Slim\Http\Headers;
-use Slim\Http\Request;
-use Slim\Http\Uri;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Factory\UriFactory;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
 
 class RequestTest extends RequestIntegrationTest
 {
     public function createSubject()
     {
-        return new Request('GET', new Uri('http', 'foo.com'), new Headers([]), [], [], new Body(fopen('php://temp', 'r+')));
+        return new Request(
+            'GET',
+            (new UriFactory())->createUri('/'),
+            new Headers([]),
+            [],
+            [],
+            (new StreamFactory())->createStream()
+        );
     }
 }

--- a/tests/Slim/ResponseTest.php
+++ b/tests/Slim/ResponseTest.php
@@ -3,7 +3,7 @@
 namespace Http\Psr7Test\Tests\Slim;
 
 use Http\Psr7Test\ResponseIntegrationTest;
-use Slim\Http\Response;
+use Slim\Psr7\Response;
 
 class ResponseTest extends ResponseIntegrationTest
 {

--- a/tests/Slim/ServerRequestTest.php
+++ b/tests/Slim/ServerRequestTest.php
@@ -2,16 +2,23 @@
 
 namespace Http\Psr7Test\Tests\Slim;
 
-use Slim\Http\Body;
-use Slim\Http\Headers;
-use Slim\Http\Request;
-use Slim\Http\Uri;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Factory\UriFactory;
+use Slim\Psr7\Headers;
+use Slim\Psr7\Request;
 use Http\Psr7Test\ServerRequestIntegrationTest;
 
 class ServerRequestTest extends ServerRequestIntegrationTest
 {
     public function createSubject()
     {
-        return new Request('GET', new Uri('http', 'foo.com'), new Headers([]), $_COOKIE, $_SERVER, new Body(fopen('php://temp', 'r+')));
+        return new Request(
+            'GET',
+            (new UriFactory())->createUri('/'),
+            new Headers([]),
+            $_COOKIE,
+            $_SERVER,
+            (new StreamFactory())->createStream()
+        );
     }
 }

--- a/tests/Slim/StreamTest.php
+++ b/tests/Slim/StreamTest.php
@@ -4,7 +4,7 @@ namespace Http\Psr7Test\Tests\Slim;
 
 use Http\Psr7Test\StreamIntegrationTest;
 use Psr\Http\Message\StreamInterface;
-use Slim\Http\Stream;
+use Slim\Psr7\Stream;
 
 class StreamTest extends StreamIntegrationTest
 {

--- a/tests/Slim/UploadedFileTest.php
+++ b/tests/Slim/UploadedFileTest.php
@@ -3,7 +3,7 @@
 namespace Http\Psr7Test\Tests\Slim;
 
 use Http\Psr7Test\UploadedFileIntegrationTest;
-use Slim\Http\UploadedFile;
+use Slim\Psr7\UploadedFile;
 
 class UploadedFileTest extends UploadedFileIntegrationTest
 {

--- a/tests/Slim/UriTest.php
+++ b/tests/Slim/UriTest.php
@@ -3,12 +3,12 @@
 namespace Http\Psr7Test\Tests\Slim;
 
 use Http\Psr7Test\UriIntegrationTest;
-use Slim\Http\Uri;
+use Slim\Psr7\Factory\UriFactory;
 
 class UriTest extends UriIntegrationTest
 {
     public function createUri($uri)
     {
-        return Uri::createFromString($uri);
+        return (new UriFactory())->createUri($uri);
     }
 }


### PR DESCRIPTION
#### What's in this PR?

PSR-7 implementation of slimphp has been moved to slim/psr7. slim/http is still existing, but as of release 0.5 this is just providing wrappers around PSR-7 implementations for convenience.