### PR TITLE
Allow withParsedBody to accept scalar values

### DIFF
--- a/src/ServerRequestIntegrationTest.php
+++ b/src/ServerRequestIntegrationTest.php
@@ -113,21 +113,25 @@ abstract class ServerRequestIntegrationTest extends BaseTest
     }
 
     /**
-     * @dataProvider invalidParsedBodyParams
-     * @expectedException \InvalidArgumentException
+     * @dataProvider optionalParsedBodyParams
      */
-    public function testGetParsedBodyInvalid($value)
+    public function testGetParsedBodyOptional($value)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $new = $this->serverRequest->withParsedBody($value);
-        $this->assertNull($this->serverRequest->getParsedBody(), 'withParsedBody MUST be immutable');
-        $this->assertEquals($value, $new->getParsedBody());
+        try {
+            $new = $this->serverRequest->withParsedBody($value);
+            $this->assertSame($value, $new->getParsedBody());
+        } catch (\InvalidArgumentException $e) {
+            // An implementation does not need to accept those values in which case it throws an \InvalidArgumentException
+        } finally {
+            $this->assertNull($this->serverRequest->getParsedBody(), 'withParsedBody MUST be immutable');
+        }
     }
 
-    public function invalidParsedBodyParams()
+    public function optionalParsedBodyParams()
     {
         return [
             [4711],


### PR DESCRIPTION
`ServerRequestInterface::withParsedBody` says
> The data IS NOT REQUIRED to come from $_POST, but MUST be the results of
> deserializing the request body content. Deserialization/parsing returns
> structured data, and, as such, this method ONLY accepts arrays or objects,
> or a null value if nothing was available to parse.
> As an example, if content negotiation determines that the request data
> is a JSON payload, this method could be used to create a request
> instance with the deserialized parameters.

A JSON body payload can also be a json string, a json int etc. So withParsedBody would also need to accept that as well. Anybody remember why this is limited to array or object? Those two sentences contradict each other.

According to a slack discussion, this was based on rfc4627

> A JSON text is a serialized object or array.

But that is outdated since since rfc7158 in 2013 which does not limit it to array or object anymore. See current https://tools.ietf.org/html/rfc8259

> A JSON text is a serialized value.  Note that certain previous
> specifications of JSON constrained a JSON text to be an object or an
> array.
