### PR TITLE
Add support for PHPUnit 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.tmp
+/.phpunit.result.cache
 /behat.yml
 /build/
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 7.1
+    - 7.2
+    - 7.3
 
 env:
     global:

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
-        "phpunit/phpunit": "^5.4 || ^6.0 || ^7.0",
+        "php": "^7.2",
+        "phpunit/phpunit": "^8.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -82,7 +82,7 @@ trait MessageTrait
         $this->assertCount(2, $message->getHeader('CONTENT-TYPE'));
         $emptyHeader = $message->getHeader('Bar');
         $this->assertCount(0, $emptyHeader);
-        $this->assertInternalType('array', $emptyHeader);
+        $this->assertIsArray($emptyHeader);
     }
 
     public function testGetHeaderLine()

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -27,7 +27,7 @@ abstract class RequestIntegrationTest extends BaseTest
      */
     abstract public function createSubject();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->request = $this->createSubject();
     }

--- a/src/ResponseIntegrationTest.php
+++ b/src/ResponseIntegrationTest.php
@@ -26,7 +26,7 @@ abstract class ResponseIntegrationTest extends BaseTest
      */
     abstract public function createSubject();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->response = $this->createSubject();
     }

--- a/src/ServerRequestIntegrationTest.php
+++ b/src/ServerRequestIntegrationTest.php
@@ -24,7 +24,7 @@ abstract class ServerRequestIntegrationTest extends BaseTest
      */
     abstract public function createSubject();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->serverRequest = $this->createSubject();
     }
@@ -114,10 +114,11 @@ abstract class ServerRequestIntegrationTest extends BaseTest
 
     /**
      * @dataProvider invalidParsedBodyParams
-     * @expectedException \InvalidArgumentException
      */
     public function testGetParsedBodyInvalid($value)
     {
+        $this->expectException('\InvalidArgumentException');
+
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
@@ -145,7 +146,7 @@ abstract class ServerRequestIntegrationTest extends BaseTest
 
         $new = $this->serverRequest->withAttribute('foo', 'bar');
         $oldAttributes = $this->serverRequest->getAttributes();
-        $this->assertInternalType('array', $oldAttributes, 'getAttributes MUST return an array');
+        $this->assertIsArray($oldAttributes, 'getAttributes MUST return an array');
         $this->assertEmpty($oldAttributes, 'withAttribute MUST be immutable');
         $this->assertEquals(['foo' => 'bar'], $new->getAttributes());
 

--- a/src/StreamIntegrationTest.php
+++ b/src/StreamIntegrationTest.php
@@ -238,10 +238,11 @@ abstract class StreamIntegrationTest extends BaseTest
 
     /**
      * @group internet
-     * @expectedException \RuntimeException
      */
     public function testRewindNotSeekable()
     {
+        $this->expectException('\RuntimeException');
+
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }

--- a/src/UploadedFileIntegrationTest.php
+++ b/src/UploadedFileIntegrationTest.php
@@ -25,13 +25,13 @@ abstract class UploadedFileIntegrationTest extends BaseTest
      */
     abstract public function createSubject();
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         @mkdir('.tmp');
         parent::setUpBeforeClass();
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->uploadedFile = $this->createSubject();
     }


### PR DESCRIPTION
When trying to fix a Slim-Psr7 compatibility issue with PHP 7.4, I ran into a bunch of failing tests due to PHPUnit 7.x not being fully compatible with PHP 7.4. These issues were fixed in PHPUnit 8, but Slim-Psr7 can't be tested with PHPUnit 8 unless this library (which Slim-Psr7 depends on) also supports PHPUnit 8.

Unfortunately it doesn't appear possible to support both PHPUnit 8 and PHPUnit 7/6/5 at the same time when implementing methods like `setUp` that have a void return type. So it may be best to either merge this PR into a branch other than master, or else tag a release, so libraries that don't support PHPUnit 8 can use it as their dependency version instead of dev-master.