### PR TITLE
Zendframework is now Laminas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
         - TEST_COMMAND="./vendor/bin/phpunit"
     matrix:
         - SUITE="Guzzle"
-        - SUITE="Zend"
+        - SUITE="Laminas"
         - SUITE="Slim"
         - SUITE="Nyholm"
         - SUITE="RingCentral"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | PSR7 Implementation | Status        |
 | ------------------- |:-------------:|
 | Guzzle              | [![Guzzle](https://travis-matrix-badges.herokuapp.com/repos/php-http/psr7-integration-tests/branches/master/1)](https://travis-ci.org/php-http/psr7-integration-tests)      |
-| Zend                | [![Zend](https://travis-matrix-badges.herokuapp.com/repos/php-http/psr7-integration-tests/branches/master/2)](https://travis-ci.org/php-http/psr7-integration-tests)        |
+| Laminas             | [![Laminas](https://travis-matrix-badges.herokuapp.com/repos/php-http/psr7-integration-tests/branches/master/2)](https://travis-ci.org/php-http/psr7-integration-tests)        |
 | Slim                | [![Slim](https://travis-matrix-badges.herokuapp.com/repos/php-http/psr7-integration-tests/branches/master/3)](https://travis-ci.org/php-http/psr7-integration-tests)        |
 | Nyholm              | [![Nyholm](https://travis-matrix-badges.herokuapp.com/repos/php-http/psr7-integration-tests/branches/master/4)](https://travis-ci.org/php-http/psr7-integration-tests)      |
 | RingCentral         | [![RingCentral](https://travis-matrix-badges.herokuapp.com/repos/php-http/psr7-integration-tests/branches/master/5)](https://travis-ci.org/php-http/psr7-integration-tests)      |

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.4",
+        "laminas/laminas-diactoros": "^2.1",
         "nyholm/psr7": "^1.0",
         "ringcentral/psr7": "^1.2",
-        "slim/psr7": "dev-master",
-        "zendframework/zend-diactoros": "^2.1"
+        "slim/psr7": "dev-master"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,8 +23,8 @@
         <directory>./tests/Slim/</directory>
     </testsuite>
 
-    <testsuite name="Zend">
-        <directory>./tests/Zend/</directory>
+    <testsuite name="Laminas">
+        <directory>./tests/Laminas/</directory>
     </testsuite>
 
     <testsuite name="Nyholm">

--- a/tests/Laminas/RequestTest.php
+++ b/tests/Laminas/RequestTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Http\Psr7Test\Tests\Zend;
+namespace Http\Psr7Test\Tests\Laminas;
 
 use Http\Psr7Test\RequestIntegrationTest;
-use Zend\Diactoros\Request;
+use Laminas\Diactoros\Request;
 
 class RequestTest extends RequestIntegrationTest
 {

--- a/tests/Laminas/ResponseTest.php
+++ b/tests/Laminas/ResponseTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Http\Psr7Test\Tests\Zend;
+namespace Http\Psr7Test\Tests\Laminas;
 
 use Http\Psr7Test\ResponseIntegrationTest;
-use Zend\Diactoros\Response;
+use Laminas\Diactoros\Response;
 
 class ResponseTest extends ResponseIntegrationTest
 {

--- a/tests/Laminas/ServerRequestTest.php
+++ b/tests/Laminas/ServerRequestTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Http\Psr7Test\Tests\Zend;
+namespace Http\Psr7Test\Tests\Laminas;
 
 use Http\Psr7Test\ServerRequestIntegrationTest;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequest;
 
 class ServerRequestTest extends ServerRequestIntegrationTest
 {

--- a/tests/Laminas/StreamTest.php
+++ b/tests/Laminas/StreamTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Http\Psr7Test\Tests\Zend;
+namespace Http\Psr7Test\Tests\Laminas;
 
 use Http\Psr7Test\StreamIntegrationTest;
+use Laminas\Diactoros\Stream;
 use Psr\Http\Message\StreamInterface;
-use Zend\Diactoros\Stream;
 
 class StreamTest extends StreamIntegrationTest
 {

--- a/tests/Laminas/UploadedFileTest.php
+++ b/tests/Laminas/UploadedFileTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Http\Psr7Test\Tests\Zend;
+namespace Http\Psr7Test\Tests\Laminas;
 
 use Http\Psr7Test\UploadedFileIntegrationTest;
-use Zend\Diactoros\Stream;
-use Zend\Diactoros\UploadedFile;
+use Laminas\Diactoros\Stream;
+use Laminas\Diactoros\UploadedFile;
 
 class UploadedFileTest extends UploadedFileIntegrationTest
 {

--- a/tests/Laminas/UriTest.php
+++ b/tests/Laminas/UriTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Http\Psr7Test\Tests\Zend;
+namespace Http\Psr7Test\Tests\Laminas;
 
 use Http\Psr7Test\UriIntegrationTest;
-use Zend\Diactoros\Uri;
+use Laminas\Diactoros\Uri;
 
 class UriTest extends UriIntegrationTest
 {


### PR DESCRIPTION
As of 2019-12-31 Zendframework was abandoned and moved to Laminas. Nowadays everyone is adding Laminas integrations to their existing Zend ones. I just renamed Zend to Laminas here to be up to date with the current implementation.