### PR TITLE
Replace deprecated assertRegExp() with assertMatchesRegularExpression()

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -93,9 +93,9 @@ trait MessageTrait
 
         $message = $this->getMessage()->withAddedHeader('content-type', 'text/html');
         $message = $message->withAddedHeader('content-type', 'text/plain');
-        $this->assertRegExp('|text/html, ?text/plain|', $message->getHeaderLine('content-type'));
-        $this->assertRegExp('|text/html, ?text/plain|', $message->getHeaderLine('Content-Type'));
-        $this->assertRegExp('|text/html, ?text/plain|', $message->getHeaderLine('CONTENT-TYPE'));
+        $this->assertMatchesRegexp('|text/html, ?text/plain|', $message->getHeaderLine('content-type'));
+        $this->assertMatchesRegexp('|text/html, ?text/plain|', $message->getHeaderLine('Content-Type'));
+        $this->assertMatchesRegexp('|text/html, ?text/plain|', $message->getHeaderLine('CONTENT-TYPE'));
 
         $this->assertSame('', $message->getHeaderLine('Bar'));
     }
@@ -121,7 +121,7 @@ trait MessageTrait
         $this->assertEquals('text/script', $message->getHeaderLine('content-type'));
 
         $message = $initialMessage->withHeader('x-foo', ['bar', 'baz']);
-        $this->assertRegExp('|bar, ?baz|', $message->getHeaderLine('x-foo'));
+        $this->assertMatchesRegexp('|bar, ?baz|', $message->getHeaderLine('x-foo'));
 
         $message = $initialMessage->withHeader('Bar', '');
         $this->assertTrue($message->hasHeader('Bar'));
@@ -162,8 +162,8 @@ trait MessageTrait
 
         $message = $this->getMessage()->withAddedHeader('content-type', 'text/html');
         $message = $message->withAddedHeader('CONTENT-type', 'text/plain');
-        $this->assertRegExp('|text/html, ?text/plain|', $message->getHeaderLine('content-type'));
-        $this->assertRegExp('|text/html, ?text/plain|', $message->getHeaderLine('Content-Type'));
+        $this->assertMatchesRegexp('|text/html, ?text/plain|', $message->getHeaderLine('content-type'));
+        $this->assertMatchesRegexp('|text/html, ?text/plain|', $message->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -192,9 +192,9 @@ trait MessageTrait
         $message = $message->withAddedHeader('content-type', ['text/plain', 'application/json']);
 
         $headerLine = $message->getHeaderLine('content-type');
-        $this->assertRegExp('|text/html|', $headerLine);
-        $this->assertRegExp('|text/plain|', $headerLine);
-        $this->assertRegExp('|application/json|', $headerLine);
+        $this->assertMatchesRegexp('|text/html|', $headerLine);
+        $this->assertMatchesRegexp('|text/plain|', $headerLine);
+        $this->assertMatchesRegexp('|application/json|', $headerLine);
     }
 
     /**
@@ -210,9 +210,9 @@ trait MessageTrait
         $message = $message->withAddedHeader('content-type', ['foo' => 'text/plain', 'bar' => 'application/json']);
 
         $headerLine = $message->getHeaderLine('content-type');
-        $this->assertRegExp('|text/html|', $headerLine);
-        $this->assertRegExp('|text/plain|', $headerLine);
-        $this->assertRegExp('|application/json|', $headerLine);
+        $this->assertMatchesRegexp('|text/html|', $headerLine);
+        $this->assertMatchesRegexp('|text/plain|', $headerLine);
+        $this->assertMatchesRegexp('|application/json|', $headerLine);
     }
 
     public function testWithoutHeader()
@@ -250,5 +250,15 @@ trait MessageTrait
         $this->assertEquals($initialMessage, $original, 'Message object MUST not be mutated');
 
         $this->assertEquals($stream, $message->getBody());
+    }
+
+    private function assertMatchesRegexp(string $pattern, string $string, string $message = ''): void
+    {
+        // @TODO remove when package require phpunit 9.1
+        if (function_exists('PHPUnit\Framework\assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            $this->assertRegExp($pattern, $string, $message);
+        }
     }
 }

--- a/src/UploadedFileIntegrationTest.php
+++ b/src/UploadedFileIntegrationTest.php
@@ -109,7 +109,12 @@ abstract class UploadedFileIntegrationTest extends BaseTest
         $file = $this->createSubject();
         $size = $file->getSize();
         if ($size) {
-            $this->assertRegExp('|^[0-9]+$|', (string) $size);
+            // @TODO remove when package require phpunit 9.1
+            if (function_exists('PHPUnit\Framework\assertMatchesRegularExpression')) {
+                $this->assertMatchesRegularExpression('|^[0-9]+$|', (string) $size);
+            } else {
+                $this->assertRegExp('|^[0-9]+$|', (string) $size);
+            }
         } else {
             $this->assertNull($size);
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | follow-up to https://github.com/php-http/psr7-integration-tests/pull/45
| Documentation   | TBD
| License         | MIT


#### What's in this PR?

In https://github.com/php-http/psr7-integration-tests/pull/45 compatibility with phpunit 9.3 was declared
But 9.3 throws warnings now on usage of `assertRegExp()` replaced with `assertMatchesRegularExpression()` in phpinit 9.1 
Ref https://phpunit.readthedocs.io/en/9.1/assertions.html#assertmatchesregularexpression 

#### Why?

Testing https://github.com/laminas/laminas-diactoros/pull/46 travis reports this warnings because it using php 8 (nightly) so composer resolves phpunit to 9.3
Also package tests reports the same https://travis-ci.org/github/php-http/psr7-integration-tests/jobs/738863983#L393


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
