### PR TITLE
Allow UploadedFile to be of size zero

### DIFF
--- a/src/UploadedFileIntegrationTest.php
+++ b/src/UploadedFileIntegrationTest.php
@@ -108,7 +108,7 @@ abstract class UploadedFileIntegrationTest extends BaseTest
 
         $file = $this->createSubject();
         $size = $file->getSize();
-        if ($size) {
+        if ($size || $size === 0) {
             // @TODO remove when package require phpunit 9.1
             if (function_exists('PHPUnit\Framework\assertMatchesRegularExpression')) {
                 $this->assertMatchesRegularExpression('|^[0-9]+$|', (string) $size);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no?
| Deprecations?   | no
| Related tickets | none
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

Patch to allow an UploadedFile instance to pass testing when it returns a (valid) integer of `0` (zero) as its size.


#### Why?

I ran into a problem when I was giving the integration tests an UploadedFile instance with an empty Stream within. At this point `getSize()` will return `0`, which does not pass the first `if`, and therefor fails the test as `0 !== null`.


#### Example Usage

``` php
class UploadedFileTest extends \Http\Psr7Test\UploadedFileIntegrationTest
{
    public function createSubject()
    {
        $stream = (new \Nyholm\Psr7\Factory\Psr17Factory())->createStream();
        return (new \Nyholm\Psr7\Factory\Psr17Factory())->createUploadedFile($stream);
    }
}

// 1) UploadedFileTest::testGetSize
// Failed asserting that 0 is null.
```