### PR TITLE
Add test for URI with multiple slashes

### DIFF
--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -226,4 +226,14 @@ abstract class UriIntegrationTest extends BaseTest
         $this->assertInstanceOf(UriInterface::class, $uri);
         $this->assertSame($expected, (string) $uri);
     }
+
+    public function testPathWithMultipleSlashes()
+    {
+        $expected = 'http://example.org//valid///path';
+        $uri = $this->createUri($expected);
+
+        $this->assertInstanceOf(UriInterface::class, $uri);
+        $this->assertSame($expected, (string) $uri);
+        $this->assertSame('//valid///path', $uri->getPath());
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   |
| License         | MIT

I've seen implementation violating the spec RFC 3986, e.g. https://github.com/zendframework/zend-diactoros/commit/68fc7424a66735926589dbaf74c0659c09e75764
So let's add a proper test for this.
