### PR TITLE
Nyholm missing integration tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,7 +28,7 @@
     </testsuite>
 
     <testsuite name="Nyholm">
-        <directory>./vendor/nyholm/psr7/tests/Integration/</directory>
+        <directory>./tests/Nyholm/</directory>
     </testsuite>
   </testsuites>
 

--- a/tests/Nyholm/RequestTest.php
+++ b/tests/Nyholm/RequestTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Http\Psr7Test\Tests\Nyholm;
+
+use Http\Psr7Test\RequestIntegrationTest;
+use Nyholm\Psr7\Request;
+
+class RequestTest extends RequestIntegrationTest
+{
+    public function createSubject()
+    {
+        return new Request('GET', '/');
+    }
+}

--- a/tests/Nyholm/ResponseTest.php
+++ b/tests/Nyholm/ResponseTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Http\Psr7Test\Tests\Nyholm;
+
+use Http\Psr7Test\ResponseIntegrationTest;
+use Nyholm\Psr7\Response;
+
+class ResponseTest extends ResponseIntegrationTest
+{
+    public function createSubject()
+    {
+        return new Response();
+    }
+}

--- a/tests/Nyholm/ServerRequestTest.php
+++ b/tests/Nyholm/ServerRequestTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Http\Psr7Test\Tests\Nyholm;
+
+use Http\Psr7Test\ServerRequestIntegrationTest;
+use Nyholm\Psr7\ServerRequest;
+
+class ServerRequestTest extends ServerRequestIntegrationTest
+{
+    public function createSubject()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        return new ServerRequest('GET', '/', [], null, '1.1', $_SERVER);
+    }
+}

--- a/tests/Nyholm/StreamTest.php
+++ b/tests/Nyholm/StreamTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Http\Psr7Test\Tests\Nyholm;
+
+use Http\Psr7Test\StreamIntegrationTest;
+use Nyholm\Psr7\Stream;
+
+class StreamTest extends StreamIntegrationTest
+{
+    public function createStream($data)
+    {
+        return Stream::create($data);
+    }
+}

--- a/tests/Nyholm/UploadedFileTest.php
+++ b/tests/Nyholm/UploadedFileTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Http\Psr7Test\Tests\Nyholm;
+
+use Http\Psr7Test\UploadedFileIntegrationTest;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Stream;
+
+class UploadedFileTest extends UploadedFileIntegrationTest
+{
+    public function createSubject()
+    {
+        return (new Psr17Factory())->createUploadedFile(Stream::create('writing to tempfile'));
+    }
+}

--- a/tests/Nyholm/UriTest.php
+++ b/tests/Nyholm/UriTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Http\Psr7Test\Tests\Nyholm;
+
+use Http\Psr7Test\UriIntegrationTest;
+use Nyholm\Psr7\Uri;
+
+class UriTest extends UriIntegrationTest
+{
+    public function createUri($uri)
+    {
+        return new Uri($uri);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

The PR include integration tests for nyholm/psr7 implementation.


#### Why?

The following command fails under PHPUnit 9.5.4, PHP 8.0.3 :
``` bash
$ composer test
...
> Test directory "/mnt/d/psr7-integration-tests/./vendor/nyholm/psr7/tests/Integration/" not found
```
php-http/psr7-integration-tests came out-of-the-box with some implementations, I think it should also include Nyholm integration with it, since "vendor/nyholm/psr7/tests" doesn't exists.
