### PR TITLE
Use sys_temp_dir() instead of mkdir in UploadedFileIntegrationTest

### DIFF
--- a/src/UploadedFileIntegrationTest.php
+++ b/src/UploadedFileIntegrationTest.php
@@ -27,7 +27,6 @@ abstract class UploadedFileIntegrationTest extends BaseTest
 
     public static function setUpBeforeClass(): void
     {
-        @mkdir('.tmp');
         parent::setUpBeforeClass();
     }
 
@@ -56,7 +55,7 @@ abstract class UploadedFileIntegrationTest extends BaseTest
 
         $file = $this->createSubject();
         $this->expectException(\RuntimeException::class);
-        $file->moveTo(sys_get_temp_dir().'/foo');
+        $file->moveTo(sys_get_temp_dir().'/'.uniqid('foo', true));
         $file->getStream();
     }
 
@@ -81,7 +80,7 @@ abstract class UploadedFileIntegrationTest extends BaseTest
         }
 
         $file = $this->createSubject();
-        $targetPath = '.tmp/'.uniqid('foo', true);
+        $targetPath = sys_get_temp_dir().'/'.uniqid('foo', true);
 
         $this->assertFalse(is_file($targetPath));
         $file->moveTo($targetPath);
@@ -96,8 +95,8 @@ abstract class UploadedFileIntegrationTest extends BaseTest
         $this->expectException(\RuntimeException::class);
 
         $file = $this->createSubject();
-        $file->moveTo('.tmp/'.uniqid('foo', true));
-        $file->moveTo('.tmp/'.uniqid('foo', true));
+        $file->moveTo(sys_get_temp_dir().'/'.uniqid('foo', true));
+        $file->moveTo(sys_get_temp_dir().'/'.uniqid('foo', true));
     }
 
     public function testGetSize()

--- a/src/UploadedFileIntegrationTest.php
+++ b/src/UploadedFileIntegrationTest.php
@@ -25,11 +25,6 @@ abstract class UploadedFileIntegrationTest extends BaseTest
      */
     abstract public function createSubject();
 
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-    }
-
     protected function setUp(): void
     {
         $this->uploadedFile = $this->createSubject();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | -
| License         | MIT


#### What's in this PR?

This PR include changes to UploadedFileIntegrationTest.php by using sys_temp_dir() rather than mkdir().


#### Why?

When using this repo as a dependency for testing against an implementation, running tests create an unwanted ".tmp" directory.

