### PR TITLE
Allow marking `testPathWithMultipleSlashes` skipped

### DIFF
--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -229,6 +229,10 @@ abstract class UriIntegrationTest extends BaseTest
 
     public function testPathWithMultipleSlashes()
     {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
         $expected = 'http://example.org//valid///path';
         $uri = $this->createUri($expected);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT


#### What's in this PR?

This PR allows marking the [`testPathWithMultipleSlashes`](https://github.com/php-http/psr7-integration-tests/blob/master/src/UriIntegrationTest.php#L230) method skipped.
