### PR TITLE
Modify multiple slash in URI path detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,12 @@
 # Change Log
+
+## Added
+
+- Adds `UriIntegrationTest::testGetPathNormalizesMultipleLeadingSlashesToSingleSlashToPreventXSS()`, `UriIntegrationTest::testStringRepresentationWithMultipleSlashes(array $test)`, and `RequestIntegrationTest::testGetRequestTargetInOriginFormNormalizesUriWithMultipleLeadingSlashesInPath()`.
+  These validate that a path containing multiple leading slashes is (a) represented with a single slash when calling `UriInterface::getPath()`, and (b) represented without changes when calling `UriInterface::__toString()`, including when calling `RequestInterface::getRequestTarget()` (which returns the path without the URI authority by default, to comply with origin-form).
+  This is done to validate mitigations for [CVE-2015-3257](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3257).
+
+## Changed
+
+- Modifies `UriIntegrationTest::testPathWithMultipleSlashes()` to only validate multiple slashes in the middle of a path.
+  Multiple leading slashes are covered with the newly introduced tests.

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -171,6 +171,11 @@ abstract class RequestIntegrationTest extends BaseTest
     }
 
     /**
+     * Tests that getRequestTarget(), when using the default behavior of
+     * displaying the origin-form, normalizes multiple leading slashes in the
+     * path to a single slash. This is done to prevent URL poisoning and/or XSS
+     * issues.
+     *
      * @see UriIntegrationTest::testGetPathNormalizesMultipleLeadingSlashesToSingleSlashToPreventXSS
      */
     public function testGetRequestTargetInOriginFormNormalizesUriWithMultipleLeadingSlashesInPath()

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -169,4 +169,20 @@ abstract class RequestIntegrationTest extends BaseTest
         $request2 = $request->withUri($this->buildUri('http://www.bar.com/foo'), true);
         $this->assertEquals($host, $request2->getHeaderLine('host'));
     }
+
+    /**
+     * @see UriIntegrationTest::testGetPathNormalizesMultipleLeadingSlashesToSingleSlashToPreventXSS
+     */
+    public function testGetRequestTargetInOriginFormNormalizesUriWithMultipleLeadingSlashesInPath()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
+        $url = 'http://example.org//valid///path';
+        $request = $this->request->withUri($this->buildUri($url));
+        $requestTarget = $request->getRequestTarget();
+
+        $this->assertSame('/valid///path', $requestTarget);
+    }
 }

--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -255,7 +255,7 @@ abstract class UriIntegrationTest extends BaseTest
 
         return [
             'expected' => $expected,
-            'uri'      => $uri,
+            'uri' => $uri,
         ];
     }
 

--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -238,6 +238,13 @@ abstract class UriIntegrationTest extends BaseTest
 
         $this->assertInstanceOf(UriInterface::class, $uri);
         $this->assertSame($expected, (string) $uri);
-        $this->assertSame('//valid///path', $uri->getPath());
+        $this->assertSame('/valid///path', $uri->getPath());
+    }
+
+    public function testProperlyTrimsLeadingSlashesToPreventXSS()
+    {
+        $url = 'http://example.org//zend.com';
+        $uri = $this->createUri($url);
+        $this->assertSame('http://example.org/zend.com', (string) $uri);
     }
 }

--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -233,18 +233,38 @@ abstract class UriIntegrationTest extends BaseTest
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
+        $expected = 'http://example.org/valid///path';
+        $uri = $this->createUri($expected);
+
+        $this->assertInstanceOf(UriInterface::class, $uri);
+        $this->assertSame('/valid///path', $uri->getPath());
+        $this->assertSame($expected, (string) $uri);
+    }
+
+    public function testGetPathNormalizesMultipleLeadingSlashesToSingleSlashToPreventXSS()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+        }
+
         $expected = 'http://example.org//valid///path';
         $uri = $this->createUri($expected);
 
         $this->assertInstanceOf(UriInterface::class, $uri);
-        $this->assertSame($expected, (string) $uri);
         $this->assertSame('/valid///path', $uri->getPath());
+
+        return [
+            'expected' => $expected,
+            'uri'      => $uri,
+        ];
     }
 
-    public function testProperlyTrimsLeadingSlashesToPreventXSS()
+    /**
+     * @depends testGetPathNormalizesMultipleLeadingSlashesToSingleSlashToPreventXSS
+     * @psalm-param array{expected: non-empty-string, uri: UriInterface} $test
+     */
+    public function testStringRepresentationWithMultipleSlashes(array $test)
     {
-        $url = 'http://example.org//zend.com';
-        $uri = $this->createUri($url);
-        $this->assertSame('http://example.org/zend.com', (string) $uri);
+        $this->assertSame($test['expected'], (string) $test['uri']);
     }
 }

--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -241,6 +241,14 @@ abstract class UriIntegrationTest extends BaseTest
         $this->assertSame($expected, (string) $uri);
     }
 
+    /**
+     * Tests that getPath() normalizes multiple leading slashes to a single
+     * slash. This is done to ensure that when a path is used in isolation from
+     * the authority, it will not cause URL poisoning and/or XSS issues.
+     *
+     * @see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3257
+     * @psalm-param array{expected: non-empty-string, uri: UriInterface} $test
+     */
     public function testGetPathNormalizesMultipleLeadingSlashesToSingleSlashToPreventXSS()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -260,6 +268,10 @@ abstract class UriIntegrationTest extends BaseTest
     }
 
     /**
+     * Tests that the full string representation of a URI that includes multiple
+     * leading slashes in the path is presented verbatim (in contrast to what is
+     * provided when calling getPath()).
+     *
      * @depends testGetPathNormalizesMultipleLeadingSlashesToSingleSlashToPreventXSS
      * @psalm-param array{expected: non-empty-string, uri: UriInterface} $test
      */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | potentially
| Deprecations?   | no
| Related tickets | fixes laminas/laminas-diactoros#74, closes laminas/laminas-diactoros#77
| Documentation   | (TBD)
| License         | MIT


#### What's in this PR?

Per an [issue created for Diactoros](https://github.com/laminas/laminas-diactoros/issues/74) its [related pull request](https://github.com/laminas/laminas-diactoros/pull/77), and the discussion to that pull request, this patch does the following:

- It modifies `testPathWithMultipleSlashes()` to only validate that multiple slashes _not at the beginning_ of a path are retained intact.
- It adds `testProperlyTrimsLeadingSlashesToPreventXSS()`, which validates that when multiple leading slashes are present in a path, they are reduced to a single slash.

#### Why?

This approach is done to mitigate [ZF2015-05](https://framework.zend.com/security/advisory/ZF2015-05.html) which was also reported as [CVE-2015-3257](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3257).
While RFC 3986 allows for multiple slashes anywhere in the path, when security conflicts with a specification, security concerns win.
Without the mitigation, an implementation is vulnerable to XSS and open redirects if only the path portion of a URI is used within HTML content (common!) or within headers (also common).

#### Example Usage

When testing a PSR-7 imlementation, ensure that URLs with multiple leading slashes in the path are rewritten to a single leading slash in order to pass the integration suite tests.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
