### PR TITLE
Build with PHP 8.0 and 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
+    - 7.2
+    - 7.3
+    - 7.4
     - 8.0
     - 8.1
     - 'nightly'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 7.2
-    - 7.3
-    - 7.4
+    - 8.0
+    - 8.1
     - 'nightly'
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "phpunit/phpunit": "^8.0 || ^9.3",
+        "phpunit/phpunit": "^9.5",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "guzzlehttp/psr7": "^2.4",
         "laminas/laminas-diactoros": "^2.22",
         "nyholm/psr7": "^1.5",
-        "ringcentral/psr7": "^1.2",
+        "ringcentral/psr7": "^1.3",
         "slim/psr7": "dev-master"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "phpunit/phpunit": "^9.5",
+        "php": "^7.2 || ^8.0",
+        "phpunit/phpunit": "^8.0 || ^9.3",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "^2.4",
-        "laminas/laminas-diactoros": "^2.22",
-        "nyholm/psr7": "^1.5",
-        "ringcentral/psr7": "^1.3",
+        "guzzlehttp/psr7": "^1.7 || ^2.0",
+        "laminas/laminas-diactoros": "^2.1",
+        "nyholm/psr7": "^1.0",
+        "ringcentral/psr7": "^1.2",
         "slim/psr7": "dev-master"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.0",
         "phpunit/phpunit": "^8.0 || ^9.3",
         "psr/http-message": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "guzzlehttp/psr7": "^2.4",
         "laminas/laminas-diactoros": "^2.22",
-        "nyholm/psr7": "^1.0",
+        "nyholm/psr7": "^1.5",
         "ringcentral/psr7": "^1.2",
         "slim/psr7": "dev-master"
     },

--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,8 @@
     },
     "scripts": {
         "test": "phpunit"
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "guzzlehttp/psr7": "^2.4",
-        "laminas/laminas-diactoros": "^2.1",
+        "laminas/laminas-diactoros": "^2.22",
         "nyholm/psr7": "^1.0",
         "ringcentral/psr7": "^1.2",
         "slim/psr7": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "^1.7 || ^2.0",
+        "guzzlehttp/psr7": "^2.4",
         "laminas/laminas-diactoros": "^2.1",
         "nyholm/psr7": "^1.0",
         "ringcentral/psr7": "^1.2",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | yes
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

This PR drops support for PHP 7.x and bumps dependencies accordingly.

This will probably require a major version release. The repositories that support PHP 7.x can continue to use the current version (`^1.2`).


#### Why?

PHP versions 7.x have reached their end of life. PHP 8.0 and 8.1 are only versions that are currently supported. PHP 8.2 will be released in a week.


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] Maybe migrate to GitHub Actions?
