### PR TITLE
Adds additional authority test case

### DIFF
--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -78,6 +78,9 @@ abstract class UriIntegrationTest extends BaseTest
 
         $uri = $this->createUri('http://user:foo@bar.com/');
         $this->assertEquals('user:foo@bar.com', $uri->getAuthority());
+
+        $uri = $this->createUri('http://bar.com:81/');
+        $this->assertEquals('bar.com:81', $uri->getAuthority());
     }
 
     public function testUserInfo()


### PR DESCRIPTION
Adds a test case for URIs with an authority part that consists of a `host` and `port` only

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes (depends on whether you're seeing this as a feature)
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

I've added an additional test case for URIs with an authority that consists of a host and port only.


#### Why?

This was a combination that was missing from the existing test cases.
#### Checklist
- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

#### Todo
Not sure whether this is an update worth mentionable in the changelog. I've decided not to.
