### PR TITLE
make request tests run for server request too #57

### DIFF
--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -20,7 +20,7 @@ abstract class RequestIntegrationTest extends BaseTest
     /**
      * @var RequestInterface
      */
-    private $request;
+    protected $request;
 
     /**
      * @return RequestInterface that is used in the tests

--- a/src/ServerRequestIntegrationTest.php
+++ b/src/ServerRequestIntegrationTest.php
@@ -7,13 +7,8 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-abstract class ServerRequestIntegrationTest extends BaseTest
+abstract class ServerRequestIntegrationTest extends RequestIntegrationTest
 {
-    /**
-     * @var array with functionName => reason
-     */
-    protected $skippedTests = [];
-
     /**
      * @var ServerRequestInterface
      */
@@ -26,6 +21,7 @@ abstract class ServerRequestIntegrationTest extends BaseTest
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->serverRequest = $this->createSubject();
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #57 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Make `ServerRequestIntegrationTest` extend `RequestIntegrationTest`.
This will make sure that no Server Request implementations break the behaviours inherited from Request.

#### Why?

In the PSR, `ServerRequestInterface` extends `RequestInterface`.
This means that a Server Request implementation should also behave like a `RequestInterface`.

Given the current structure of the tests, it is not easy to verify this.
`RequestIntegrationTest` and `ServerRequestIntegrationTest` both extend `BaseTest`.
In order to check if a Server Request behaves like both a Server Request and a Request, we currently need to create 2 test classes:
- one that extends `ServerRequestIntegrationTest`
- one that extends `RequestIntegrationTest`

This PR aims to simplify this by requiring only one test class to check if a ServerRequest also behaves like a Request.
