### PR TITLE
Allow `psr/http-message` v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - TBD
 
+### Added
+
+- Support for `psr/http-message` v2
+
 ## [1.2.0] - 2022-12-01
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "phpunit/phpunit": "^8.0 || ^9.3",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.7 || ^2.0",
         "laminas/laminas-diactoros": "^2.1",
         "nyholm/psr7": "^1.0",
         "ringcentral/psr7": "^1.2",
-        "slim/psr7": "dev-master"
+        "slim/psr7": "^1.4"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #64
| Documentation   | So far, nothing changes
| License         | MIT


#### What's in this PR?

Provides support for `psr/http-message` v2


#### Why?

Executing tests with `psr/http-message` v2 won't work due to dependency conflicts.


#### Example Usage

/

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

- [x] Update CHANGELOG.md
