### PR TITLE
Introduce `userInfo` encoding tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - TBD
 
+### Added
+
+- Adds `UriIntegrationTest::testSpecialCharsInUserInfo` and `UriIntegrationTest::testAlreadyEncodedUserInfo`.
+  These validate that usernames and passwords which contain reserved characters (defined by RFC3986) are being encoded
+  so that the URI does not contain these reserved characters at any time.
+
 ## [1.2.0] - 2022-12-01
 
 ### Added

--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -281,4 +281,28 @@ abstract class UriIntegrationTest extends BaseTest
     {
         $this->assertSame($test['expected'], (string) $test['uri']);
     }
+
+    /**
+     * Tests that special chars in `userInfo` must always be URL-encoded to pass RFC3986 compliant URIs where characters
+     * in username and password MUST NOT contain reserved characters.
+     *
+     * This test is taken from {@see https://github.com/guzzle/psr7/blob/3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf/tests/UriTest.php#L679-L688 guzzlehttp/psr7}.
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc3986#appendix-A
+     */
+    public function testSpecialCharsInUserInfo(): void
+    {
+        $uri = $this->createUri('/')->withUserInfo('foo@bar.com', 'pass#word');
+        self::assertSame('foo%40bar.com:pass%23word', $uri->getUserInfo());
+    }
+
+    /**
+     * Tests that userinfo which is already encoded is not encoded twice.
+     * This test is taken from {@see https://github.com/guzzle/psr7/blob/3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf/tests/UriTest.php#L679-L688 guzzlehttp/psr7}.
+     */
+    public function testAlreadyEncodedUserInfo(): void
+    {
+        $uri = $this->createUri('/')->withUserInfo('foo%40bar.com', 'pass%23word');
+        self::assertSame('foo%40bar.com:pass%23word', $uri->getUserInfo());
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #61
| License         | MIT


#### What's in this PR?

There are two new tests added which verify that the `UriInterface#withUserInfo` can handle both already encoded and reserved characters.


#### Why?

Due to the interoperability idea, all PSR-7 implementations should behave the same. I recently found out that not all PSR-7 implementations do behave the same and thus I ended up having invalid URIs.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

- [x] Update CHANGELOG after #66 is merged
