### PR TITLE
Adapt tests to work with v1.1 and v2.0 of PSR-7

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,6 @@ jobs:
         # and finally require the implementation to test with source flag (to get integration test cases that might be excluded in git-attributes)
         run: |
           composer remove --dev guzzlehttp/psr7 laminas/laminas-diactoros nyholm/psr7 ringcentral/psr7 slim/psr7 --no-update
-          composer update --no-interaction --no-progress
           composer require ${{ inputs.package }} --no-interaction --no-progress --prefer-source
 
       - name: Execute tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   These validate that usernames and passwords which contain reserved characters (defined by RFC3986) are being encoded
   so that the URI does not contain these reserved characters at any time.
 
+- Adds support for testing against PSR-7 1.1 and 2.0. In particular, it adapts tests that were verifying invalid parameters threw `InvalidArgumentException` previously now either throw that OR (more correctly) raise a `TypeError`.
+
 ## [1.2.0] - 2022-12-01
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "phpunit/phpunit": "^8.0 || ^9.3",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^1.7 || ^2.0",
         "laminas/laminas-diactoros": "^2.1",
         "nyholm/psr7": "^1.0",
         "ringcentral/psr7": "^1.2",
-        "slim/psr7": "dev-master"
+        "slim/psr7": "^1.4"
     },
     "extra": {
         "branch-alias": {

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -145,6 +145,7 @@ trait MessageTrait
             $initialMessage->withHeader($name, $value);
         } catch (TypeError|InvalidArgumentException $e) {
             // valid
+            $this->assertTrue($e instanceof Throwable);
         } catch (Throwable $e) {
             // invalid
             $this->fail(sprintf(
@@ -193,6 +194,7 @@ trait MessageTrait
             $initialMessage->withAddedHeader($name, $value);
         } catch (TypeError|InvalidArgumentException $e) {
             // valid
+            $this->assertTrue($e instanceof Throwable);
         } catch (Throwable $e) {
             // invalid
             $this->fail(sprintf(

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -3,6 +3,7 @@
 namespace Http\Psr7Test;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\AssertionFailedError;
 use Psr\Http\Message\MessageInterface;
 use Throwable;
 use TypeError;
@@ -143,6 +144,10 @@ trait MessageTrait
         try {
             $initialMessage = $this->getMessage();
             $initialMessage->withHeader($name, $value);
+            $this->fail('withHeader() should have raised exception on invalid argument');
+        } catch (AssertionFailedError $e) {
+            // invalid argument not caught
+            throw $e;
         } catch (TypeError|InvalidArgumentException $e) {
             // valid
             $this->assertTrue($e instanceof Throwable);
@@ -192,6 +197,10 @@ trait MessageTrait
         try {
             $initialMessage = $this->getMessage();
             $initialMessage->withAddedHeader($name, $value);
+            $this->fail('withAddedHeader() should have raised exception on invalid argument');
+        } catch (AssertionFailedError $e) {
+            // invalid argument not caught
+            throw $e;
         } catch (TypeError|InvalidArgumentException $e) {
             // valid
             $this->assertTrue($e instanceof Throwable);

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -2,7 +2,10 @@
 
 namespace Http\Psr7Test;
 
+use InvalidArgumentException;
 use Psr\Http\Message\MessageInterface;
+use Throwable;
+use TypeError;
 
 /**
  * Test MessageInterface.
@@ -136,9 +139,19 @@ trait MessageTrait
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
-        $this->expectException(\InvalidArgumentException::class);
-        $initialMessage = $this->getMessage();
-        $initialMessage->withHeader($name, $value);
+
+        try {
+            $initialMessage = $this->getMessage();
+            $initialMessage->withHeader($name, $value);
+        } catch (TypeError|InvalidArgumentException $e) {
+            // valid
+        } catch (Throwable $e) {
+            // invalid
+            $this->fail(sprintf(
+                'Unexpected exception (%s) thrown from withHeader(); expected TypeError or InvalidArgumentException',
+                gettype($e)
+            ));
+        }
     }
 
     public function getInvalidHeaderArguments()
@@ -153,6 +166,7 @@ trait MessageTrait
             [new \stdClass(), 'foo'],
         ];
     }
+
 
     public function testWithAddedHeader()
     {
@@ -174,9 +188,19 @@ trait MessageTrait
         if (isset($this->skippedTests[__FUNCTION__])) {
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
-        $this->expectException(\InvalidArgumentException::class);
-        $initialMessage = $this->getMessage();
-        $initialMessage->withAddedHeader($name, $value);
+
+        try {
+            $initialMessage = $this->getMessage();
+            $initialMessage->withAddedHeader($name, $value);
+        } catch (TypeError|InvalidArgumentException $e) {
+            // valid
+        } catch (Throwable $e) {
+            // invalid
+            $this->fail(sprintf(
+                'Unexpected exception (%s) thrown from withAddedHeader(); expected TypeError or InvalidArgumentException',
+                gettype($e)
+            ));
+        }
     }
 
     /**

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -167,7 +167,6 @@ trait MessageTrait
         ];
     }
 
-
     public function testWithAddedHeader()
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -103,6 +103,7 @@ abstract class RequestIntegrationTest extends BaseTest
             $this->request->withMethod($method);
         } catch (InvalidArgumentException|TypeError $e) {
             // valid
+            $this->assertTrue($e instanceof Throwable);
         } catch (Throwable $e) {
             // invalid
             $this->fail(sprintf(

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -121,12 +121,10 @@ abstract class RequestIntegrationTest extends BaseTest
     public function getInvalidMethods()
     {
         return [
-            [null],
-            [1],
-            [1.01],
-            [false],
-            [['foo']],
-            [new \stdClass()],
+            'null'   => [null],
+            'false'  => [false],
+            'array'  => [['foo']],
+            'object' => [new \stdClass()],
         ];
     }
 

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -121,9 +121,9 @@ abstract class RequestIntegrationTest extends BaseTest
     public function getInvalidMethods()
     {
         return [
-            'null'   => [null],
-            'false'  => [false],
-            'array'  => [['foo']],
+            'null' => [null],
+            'false' => [false],
+            'array' => [['foo']],
             'object' => [new \stdClass()],
         ];
     }

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace Http\Psr7Test;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\AssertionFailedError;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 use Throwable;
@@ -101,6 +102,10 @@ abstract class RequestIntegrationTest extends BaseTest
 
         try {
             $this->request->withMethod($method);
+            $this->fail('withMethod() should have raised exception on invalid argument');
+        } catch (AssertionFailedError $e) {
+            // invalid argument not caught
+            throw $e;
         } catch (InvalidArgumentException|TypeError $e) {
             // valid
             $this->assertTrue($e instanceof Throwable);

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -2,8 +2,11 @@
 
 namespace Http\Psr7Test;
 
+use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
+use Throwable;
+use TypeError;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -96,8 +99,17 @@ abstract class RequestIntegrationTest extends BaseTest
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->request->withMethod($method);
+        try {
+            $this->request->withMethod($method);
+        } catch (InvalidArgumentException|TypeError $e) {
+            // valid
+        } catch (Throwable $e) {
+            // invalid
+            $this->fail(sprintf(
+                'Unexpected exception (%s) thrown from withMethod(); expected TypeError or InvalidArgumentException',
+                gettype($e)
+            ));
+        }
     }
 
     public function getInvalidMethods()

--- a/src/ResponseIntegrationTest.php
+++ b/src/ResponseIntegrationTest.php
@@ -65,6 +65,7 @@ abstract class ResponseIntegrationTest extends BaseTest
             $this->response->withStatus($statusCode);
         } catch (InvalidArgumentException|TypeError $e) {
             // valid
+            $this->assertTrue($e instanceof Throwable);
         } catch (Throwable $e) {
             // invalid
             $this->fail(sprintf(

--- a/src/ResponseIntegrationTest.php
+++ b/src/ResponseIntegrationTest.php
@@ -83,11 +83,11 @@ abstract class ResponseIntegrationTest extends BaseTest
     public function getInvalidStatusCodeArguments()
     {
         return [
-            'true'     => [true],
-            'string'   => ['foobar'],
-            'too-low'  => [99],
+            'true' => [true],
+            'string' => ['foobar'],
+            'too-low' => [99],
             'too-high' => [600],
-            'object'   => [new \stdClass()],
+            'object' => [new \stdClass()],
         ];
     }
 

--- a/src/ResponseIntegrationTest.php
+++ b/src/ResponseIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace Http\Psr7Test;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\AssertionFailedError;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 use TypeError;
@@ -63,6 +64,10 @@ abstract class ResponseIntegrationTest extends BaseTest
 
         try {
             $this->response->withStatus($statusCode);
+            $this->fail('withStatus() should have raised exception on invalid argument');
+        } catch (AssertionFailedError $e) {
+            // invalid argument not caught
+            throw $e;
         } catch (InvalidArgumentException|TypeError $e) {
             // valid
             $this->assertTrue($e instanceof Throwable);

--- a/src/ResponseIntegrationTest.php
+++ b/src/ResponseIntegrationTest.php
@@ -83,12 +83,11 @@ abstract class ResponseIntegrationTest extends BaseTest
     public function getInvalidStatusCodeArguments()
     {
         return [
-            [true],
-            ['foobar'],
-            [99],
-            [600],
-            [200.34],
-            [new \stdClass()],
+            'true'     => [true],
+            'string'   => ['foobar'],
+            'too-low'  => [99],
+            'too-high' => [600],
+            'object'   => [new \stdClass()],
         ];
     }
 

--- a/src/ResponseIntegrationTest.php
+++ b/src/ResponseIntegrationTest.php
@@ -2,7 +2,10 @@
 
 namespace Http\Psr7Test;
 
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
+use Throwable;
+use TypeError;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -58,8 +61,17 @@ abstract class ResponseIntegrationTest extends BaseTest
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->response->withStatus($statusCode);
+        try {
+            $this->response->withStatus($statusCode);
+        } catch (InvalidArgumentException|TypeError $e) {
+            // valid
+        } catch (Throwable $e) {
+            // invalid
+            $this->fail(sprintf(
+                'Unexpected exception (%s) thrown from withStatus(); expected TypeError or InvalidArgumentException',
+                gettype($e)
+            ));
+        }
     }
 
     public function getInvalidStatusCodeArguments()

--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -2,7 +2,10 @@
 
 namespace Http\Psr7Test;
 
+use InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
+use Throwable;
+use TypeError;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -47,8 +50,17 @@ abstract class UriIntegrationTest extends BaseTest
             $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
         }
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->createUri('/')->withScheme($schema);
+        try {
+            $this->createUri('/')->withScheme($schema);
+        } catch (InvalidArgumentException|TypeError $e) {
+            // valid
+        } catch (Throwable $e) {
+            // invalid
+            $this->fail(sprintf(
+                'Unexpected exception (%s) thrown from withScheme(); expected TypeError or InvalidArgumentException',
+                gettype($e)
+            ));
+        }
     }
 
     public function getInvalidSchemaArguments()

--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace Http\Psr7Test;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\AssertionFailedError;
 use Psr\Http\Message\UriInterface;
 use Throwable;
 use TypeError;
@@ -52,6 +53,10 @@ abstract class UriIntegrationTest extends BaseTest
 
         try {
             $this->createUri('/')->withScheme($schema);
+            $this->fail('withScheme() should have raised exception on invalid argument');
+        } catch (AssertionFailedError $e) {
+            // invalid argument not caught
+            throw $e;
         } catch (InvalidArgumentException|TypeError $e) {
             // valid
             $this->assertTrue($e instanceof Throwable);

--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -54,6 +54,7 @@ abstract class UriIntegrationTest extends BaseTest
             $this->createUri('/')->withScheme($schema);
         } catch (InvalidArgumentException|TypeError $e) {
             // valid
+            $this->assertTrue($e instanceof Throwable);
         } catch (Throwable $e) {
             // invalid
             $this->fail(sprintf(


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Provides more comprehensive change than #65. Fix #64
| Documentation   | TBD
| License         | MIT


#### What's in this PR?

Refactors tests that were using the assumption of throwing an `InvalidArgumentException` to test for either `InvalidArgumentException` OR `TypeError`.

The change goes further than #65 in that it provides test changes, not just dependency changes. The test changes have been vetted by running against a laminas-diactoros checkout that modifies its codebase to conform to the PSR-7 changes.

#### Why?

This change will allow testing against PSR-7 1.1+ releases safely.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
