### PR TITLE
Add support for PHPUnit 11 and 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "phpunit/phpunit": "^9.3 || ^10.0",
+        "phpunit/phpunit": "^9.3 || ^10.0 || ^11.5 || ^12.4",
         "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -4,6 +4,7 @@ namespace Http\Psr7Test;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\MessageInterface;
 use Throwable;
 use TypeError;
@@ -135,6 +136,7 @@ trait MessageTrait
     /**
      * @dataProvider getInvalidHeaderArguments
      */
+    #[DataProvider('getInvalidHeaderArguments')]
     public function testWithHeaderInvalidArguments($name, $value)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -188,6 +190,7 @@ trait MessageTrait
     /**
      * @dataProvider getInvalidHeaderArguments
      */
+    #[DataProvider('getInvalidHeaderArguments')]
     public function testWithAddedHeaderInvalidArguments($name, $value)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/RequestIntegrationTest.php
+++ b/src/RequestIntegrationTest.php
@@ -4,6 +4,7 @@ namespace Http\Psr7Test;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 use Throwable;
@@ -94,6 +95,7 @@ abstract class RequestIntegrationTest extends BaseTest
     /**
      * @dataProvider getInvalidMethods
      */
+    #[DataProvider('getInvalidMethods')]
     public function testMethodWithInvalidArguments($method)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/ResponseIntegrationTest.php
+++ b/src/ResponseIntegrationTest.php
@@ -4,6 +4,7 @@ namespace Http\Psr7Test;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 use TypeError;
@@ -56,6 +57,7 @@ abstract class ResponseIntegrationTest extends BaseTest
     /**
      * @dataProvider getInvalidStatusCodeArguments
      */
+    #[DataProvider('getInvalidStatusCodeArguments')]
     public function testStatusCodeInvalidArgument($statusCode)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/ServerRequestIntegrationTest.php
+++ b/src/ServerRequestIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Http\Psr7Test;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -88,6 +89,7 @@ abstract class ServerRequestIntegrationTest extends RequestIntegrationTest
     /**
      * @dataProvider validParsedBodyParams
      */
+    #[DataProvider('validParsedBodyParams')]
     public function testGetParsedBody($value)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -111,6 +113,7 @@ abstract class ServerRequestIntegrationTest extends RequestIntegrationTest
     /**
      * @dataProvider invalidParsedBodyParams
      */
+    #[DataProvider('invalidParsedBodyParams')]
     public function testGetParsedBodyInvalid($value)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {

--- a/src/UriIntegrationTest.php
+++ b/src/UriIntegrationTest.php
@@ -4,6 +4,8 @@ namespace Http\Psr7Test;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use Psr\Http\Message\UriInterface;
 use Throwable;
 use TypeError;
@@ -45,6 +47,7 @@ abstract class UriIntegrationTest extends BaseTest
     /**
      * @dataProvider getInvalidSchemaArguments
      */
+    #[DataProvider('getInvalidSchemaArguments')]
     public function testWithSchemeInvalidArguments($schema)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -155,6 +158,7 @@ abstract class UriIntegrationTest extends BaseTest
     /**
      * @dataProvider getPaths
      */
+    #[DataProvider('getPaths')]
     public function testPath(UriInterface $uri, string $expected)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -181,6 +185,7 @@ abstract class UriIntegrationTest extends BaseTest
     /**
      * @dataProvider getQueries
      */
+    #[DataProvider('getQueries')]
     public function testQuery(UriInterface $uri, string $expected)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -206,6 +211,7 @@ abstract class UriIntegrationTest extends BaseTest
     /**
      * @dataProvider getFragments
      */
+    #[DataProvider('getFragments')]
     public function testFragment(UriInterface $uri, string $expected)
     {
         if (isset($this->skippedTests[__FUNCTION__])) {
@@ -304,6 +310,7 @@ abstract class UriIntegrationTest extends BaseTest
      *
      * @psalm-param array{expected: non-empty-string, uri: UriInterface} $test
      */
+    #[Depends('testGetPathNormalizesMultipleLeadingSlashesToSingleSlashToPreventXSS')]
     public function testStringRepresentationWithMultipleSlashes(array $test)
     {
         $this->assertSame($test['expected'], (string) $test['uri']);


### PR DESCRIPTION
Aside for the required use of attributes instead of annotations no other changes appear to be needed.