### PR TITLE
Update Laminas integration

### DIFF
--- a/.github/workflows/laminas-legacy.yml
+++ b/.github/workflows/laminas-legacy.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.3', '7.4' ]
+        php: [ '7.3', '7.4', '8.0', '8.1' ]
     uses: ./.github/workflows/integration.yml
     with:
       php: ${{ matrix.php }}

--- a/.github/workflows/laminas.yml
+++ b/.github/workflows/laminas.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '8.1', '8.2' ]
+        php: [ '8.2', '8.3', '8.4' ]
     uses: ./.github/workflows/integration.yml
     with:
       php: ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "f3-factory/fatfree-psr7": "^2.0",
         "guzzlehttp/psr7": "^1.7 || ^2.0",
         "httpsoft/http-message": "^1.1",
-        "laminas/laminas-diactoros": "^2.1",
+        "laminas/laminas-diactoros": "^2.1 || ^3.0",
         "nyholm/psr7": "^1.0",
         "ringcentral/psr7": "^1.2",
         "slim/psr7": "^1.4"


### PR DESCRIPTION
Laminas supports only maintained PHP versions. Update Laminas integration and move unsupported version to legacy.

Having laminas-diactoros as dev dependency along with all the others seems kinda useless tbh. They all interfere with each other most likely.
